### PR TITLE
Make scraper write directly to DB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ COPY setup.py /app/clinical-trials-api-scraper
 RUN pip install /app/clinical-trials-api-scraper
 
 # Run scraper once to bootstrap db then set up cron
-CMD update_trials_store.py --max-id 100 --use-sql --host ${GRAPHQL_HOST} --port ${GRAPHQL_PORT} && sleep ${SECONDS_BETWEEN_SCRAPES}
+CMD update_trials_store.py --max-id ${SCRAPER_MAX_ID} ${SCRAPER_USE_SQL_FLAG} --host ${GRAPHQL_HOST} --port ${GRAPHQL_PORT} && sleep ${SECONDS_BETWEEN_SCRAPES}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.5-alpine
+# Using debian buster because this: https://pythonspeed.com/articles/base-image-python-docker-images/
+FROM python:3.7-slim-buster
 
 WORKDIR /app
 COPY clinical_trials_api_scraper /app/clinical-trials-api-scraper/clinical_trials_api_scraper
@@ -6,10 +7,5 @@ COPY setup.py /app/clinical-trials-api-scraper
 
 RUN pip install /app/clinical-trials-api-scraper
 
-#Set up cron
-COPY daily-trials-scraping /etc/cron.d/daily-trials-scraping
-RUN chmod 0644 /etc/cron.d/daily-trials-scraping
-RUN crontab /etc/cron.d/daily-trials-scraping
-
 # Run scraper once to bootstrap db then set up cron
-CMD update_trials_store.py --max-id 100 && crond -f -l 8
+CMD update_trials_store.py --max-id 100 --host ${GRAPHQL_HOST} --port ${GRAPHQL_PORT} && sleep ${SECONDS_BETWEEN_SCRAPES}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ COPY setup.py /app/clinical-trials-api-scraper
 RUN pip install /app/clinical-trials-api-scraper
 
 # Run scraper once to bootstrap db then set up cron
-CMD update_trials_store.py --max-id 100 --host ${GRAPHQL_HOST} --port ${GRAPHQL_PORT} && sleep ${SECONDS_BETWEEN_SCRAPES}
+CMD update_trials_store.py --max-id 100 --use-sql --host ${GRAPHQL_HOST} --port ${GRAPHQL_PORT} && sleep ${SECONDS_BETWEEN_SCRAPES}

--- a/clinical_trials_api_scraper/clients/sql_trials_store_client.py
+++ b/clinical_trials_api_scraper/clients/sql_trials_store_client.py
@@ -2,19 +2,21 @@ import logging
 from sqlalchemy import create_engine, MetaData, Table
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.ext.declarative import declarative_base, DeferredReflection
+from sqlalchemy.ext.automap import automap_base
 
 
 from clinical_trials_api_scraper.clients.trials_store_interface_base import \
     TrialsStoreInterfaceBase
-from clinical_trials_api_scraper.utils.trial_model_utils import trial_from_response_data, dict_to_snake_case, extract_institution_from_trial
+import clinical_trials_api_scraper.utils.trial_model_utils as tmu
 
 
 DB_SCHEMA = "trials_status_schema"
 
 logger = logging.getLogger(__name__)
 
-Base = declarative_base(cls=DeferredReflection,
-                        metadata=MetaData(schema=DB_SCHEMA))
+# Base = declarative_base(cls=DeferredReflection,
+#                         metadata=MetaData(schema=DB_SCHEMA))
+Base = automap_base(metadata=MetaData(schema=DB_SCHEMA))
 
 
 class Institution(Base):
@@ -31,7 +33,7 @@ class SqlTrialsStoreClient(TrialsStoreInterfaceBase):
     def __init__(self):
         self.engine = create_engine(
             'postgres://postgres:1234@db:5432/{}'.format(self.db_name), echo=False)
-        Base.prepare(self.engine)
+        Base.prepare(self.engine, reflect=True)
         Session = sessionmaker(bind=self.engine)
         self.session = Session()
         logger.info(Trial.__table__.columns)
@@ -39,15 +41,22 @@ class SqlTrialsStoreClient(TrialsStoreInterfaceBase):
 
     def store_trials_batch(self, trials_batch):
         logger.info('storing {} values'.format(len(trials_batch)))
-        trials = [trial_from_response_data(t) for t in trials_batch]
-        institutions = [dict_to_snake_case(
-            extract_institution_from_trial(t)) for t in trials]
-        for institution in institutions[:5]:
-            logger.info(institution)
-            self.session.add(Institution(**institution))
-        for trial in trials[:5]:
-            logger.info(trial)
-            self.session.add(Trial(**dict_to_snake_case(trial)))
+        trials = [tmu.trial_from_response_data(t) for t in trials_batch]
+        #institution_dict = {}
+        for full_trial in trials:
+            institution, trial = tmu.split_institution_trial(full_trial)
+            inst_obj = Institution(
+                **tmu.dict_to_snake_case(institution))
+            #institution_key = (inst_obj.org_name, inst_obj.org_type)
+
+            # deduplicate institutions
+            #inst_obj = institution_dict.setdefault(institution_key, inst_obj)
+
+            trial['institution'] = inst_obj
+            trial_obj = Trial(**tmu.dict_to_snake_case(trial))
+            self.session.merge(trial_obj)
+            logger.info(
+                f'storing trial {trial_obj.id} from {inst_obj.org_name}')
         self.session.commit()
 
     def is_ready(self):

--- a/clinical_trials_api_scraper/clients/sql_trials_store_client.py
+++ b/clinical_trials_api_scraper/clients/sql_trials_store_client.py
@@ -1,0 +1,54 @@
+import logging
+from sqlalchemy import create_engine, MetaData, Table
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.ext.declarative import declarative_base, DeferredReflection
+
+
+from clinical_trials_api_scraper.clients.trials_store_interface_base import \
+    TrialsStoreInterfaceBase
+from clinical_trials_api_scraper.utils.trial_model_utils import trial_from_response_data, dict_to_snake_case, extract_institution_from_trial
+
+
+DB_SCHEMA = "trials_status_schema"
+
+logger = logging.getLogger(__name__)
+
+Base = declarative_base(cls=DeferredReflection,
+                        metadata=MetaData(schema=DB_SCHEMA))
+
+
+class Institution(Base):
+    __tablename__ = 'institutions'
+
+
+class Trial(Base):
+    __tablename__ = 'trials'
+
+
+class SqlTrialsStoreClient(TrialsStoreInterfaceBase):
+    db_name = "clinical_trials_status"
+
+    def __init__(self):
+        self.engine = create_engine(
+            'postgres://postgres:1234@db:5432/{}'.format(self.db_name), echo=False)
+        Base.prepare(self.engine)
+        Session = sessionmaker(bind=self.engine)
+        self.session = Session()
+        logger.info(Trial.__table__.columns)
+        logger.info(Institution.__table__.columns)
+
+    def store_trials_batch(self, trials_batch):
+        logger.info('storing {} values'.format(len(trials_batch)))
+        trials = [trial_from_response_data(t) for t in trials_batch]
+        institutions = [dict_to_snake_case(
+            extract_institution_from_trial(t)) for t in trials]
+        for institution in institutions[:5]:
+            logger.info(institution)
+            self.session.add(Institution(**institution))
+        for trial in trials[:5]:
+            logger.info(trial)
+            self.session.add(Trial(**dict_to_snake_case(trial)))
+        self.session.commit()
+
+    def is_ready(self):
+        return True

--- a/clinical_trials_api_scraper/scripts/update_trials_store.py
+++ b/clinical_trials_api_scraper/scripts/update_trials_store.py
@@ -12,14 +12,16 @@ logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-def main(min_id=None, max_id=None, in_memory=False):
+def main(min_id=None, max_id=None, in_memory=False, host="localhost", port=5000):
+    logger.info("I am different3")
     if in_memory:
         store = InMemoryTrialsStoreClient()
     else:
-        store = GqlTrialsStoreClient()
+        store = GqlTrialsStoreClient(host, port)
     if not store.is_ready():
         raise ValueError("Store not ready for data")
-    scraper = ClinicalTrialsScraper(data_store_client=store, min_id=min_id, max_id=max_id)
+    scraper = ClinicalTrialsScraper(
+        data_store_client=store, min_id=min_id, max_id=max_id)
     scraper.scrape_all_trials()
     logger.info("Completed scraping trials")
 
@@ -31,10 +33,16 @@ if __name__ == "__main__":
     parser.add_argument("--min-id", type=int, required=False)
     parser.add_argument("--max-id", type=int, required=False)
     parser.add_argument("--in-memory", action='store_true')
+    parser.add_argument("--host")
+    parser.add_argument("--port")
     args = parser.parse_args()
+
+    logger.info(args)
 
     main(
         min_id=args.min_id,
         max_id=args.max_id,
-        in_memory=args.in_memory
+        in_memory=args.in_memory,
+        host=args.host,
+        port=args.port
     )

--- a/clinical_trials_api_scraper/scripts/update_trials_store.py
+++ b/clinical_trials_api_scraper/scripts/update_trials_store.py
@@ -5,6 +5,7 @@ import sys
 from clinical_trials_api_scraper.clients.in_memory_trials_store_client import \
     InMemoryTrialsStoreClient
 from clinical_trials_api_scraper.clients.gql_trials_store_client import GqlTrialsStoreClient
+from clinical_trials_api_scraper.clients.sql_trials_store_client import SqlTrialsStoreClient
 from clinical_trials_api_scraper.scrapers.clinical_trials_scraper import ClinicalTrialsScraper
 
 
@@ -12,9 +13,11 @@ logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-def main(min_id=None, max_id=None, in_memory=False, host="localhost", port=5000):
+def main(min_id=None, max_id=None, in_memory=False, use_sql=False, host="localhost", port=5000):
     if in_memory:
         store = InMemoryTrialsStoreClient()
+    elif use_sql:
+        store = SqlTrialsStoreClient()
     else:
         store = GqlTrialsStoreClient(host, port)
     if not store.is_ready():
@@ -32,6 +35,7 @@ if __name__ == "__main__":
     parser.add_argument("--min-id", type=int, required=False)
     parser.add_argument("--max-id", type=int, required=False)
     parser.add_argument("--in-memory", action='store_true')
+    parser.add_argument("--use-sql", action='store_true')
     parser.add_argument("--host")
     parser.add_argument("--port")
     args = parser.parse_args()
@@ -42,6 +46,7 @@ if __name__ == "__main__":
         min_id=args.min_id,
         max_id=args.max_id,
         in_memory=args.in_memory,
+        use_sql=args.use_sql,
         host=args.host,
         port=args.port
     )

--- a/clinical_trials_api_scraper/scripts/update_trials_store.py
+++ b/clinical_trials_api_scraper/scripts/update_trials_store.py
@@ -13,7 +13,6 @@ logger = logging.getLogger(__name__)
 
 
 def main(min_id=None, max_id=None, in_memory=False, host="localhost", port=5000):
-    logger.info("I am different3")
     if in_memory:
         store = InMemoryTrialsStoreClient()
     else:

--- a/clinical_trials_api_scraper/utils/trial_model_utils.py
+++ b/clinical_trials_api_scraper/utils/trial_model_utils.py
@@ -34,7 +34,9 @@ def split_institution_trial(full_trial):
     trial = full_trial.copy()
     institution = {}
     for field in INSTITUTION_FIELDS:
-        institution[field] = trial.pop(field)
+        value = trial.pop(field)
+        value = '' if value is None else value
+        institution[field] = value
     return institution, trial
 
 

--- a/clinical_trials_api_scraper/utils/trial_model_utils.py
+++ b/clinical_trials_api_scraper/utils/trial_model_utils.py
@@ -22,11 +22,13 @@ DATE_FIELDS = ['completionDate', 'clinicaltrialsUpdatedAt']
 
 INSTITUTION_FIELDS = ['orgName', 'orgType']
 
+
 def extract_institution_from_trial(trial):
     institution = {}
     for field in INSTITUTION_FIELDS:
         institution[field] = trial.pop(field)
     return institution
+
 
 def trial_from_response_data(response_data):
     trial_model = {
@@ -36,5 +38,16 @@ def trial_from_response_data(response_data):
 
     for time_field in DATE_FIELDS:
         if trial_model.get(time_field):
-            trial_model[time_field] = parser.parse(trial_model[time_field]).isoformat()
+            trial_model[time_field] = parser.parse(
+                trial_model[time_field]).isoformat()
     return trial_model
+
+
+def dict_to_snake_case(d):
+    return {to_snake_case(k): v for k, v in d.items()}
+
+
+def to_snake_case(str):
+
+    return ''.join(['_'+i.lower() if i.isupper()
+                    else i for i in str]).lstrip('_')

--- a/clinical_trials_api_scraper/utils/trial_model_utils.py
+++ b/clinical_trials_api_scraper/utils/trial_model_utils.py
@@ -30,6 +30,14 @@ def extract_institution_from_trial(trial):
     return institution
 
 
+def split_institution_trial(full_trial):
+    trial = full_trial.copy()
+    institution = {}
+    for field in INSTITUTION_FIELDS:
+        institution[field] = trial.pop(field)
+    return institution, trial
+
+
 def trial_from_response_data(response_data):
     trial_model = {
         new_key: response_data.get(old_key) for new_key, old_key in RESPONSE_TO_TRIAL_MAP.items()

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,8 @@ setup(
     # long_description=open('README.md').read(),
     install_requires=[
         "requests",
-        "python-dateutil"
+        "python-dateutil",
+        "sqlalchemy",
+        "psycopg2-binary"
     ],
 )


### PR DESCRIPTION
- Enable mode that uses `sqlalchemy` to write directly to DB
- Make the scraper more configurable via environment variables 
- Some annoying autoformatting

Note: GraphQL writing may be broken now, I haven't tested it thoroughly.