### PR TITLE
Scraper MVP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ COPY setup.py /app/clinical-trials-api-scraper
 RUN pip install /app/clinical-trials-api-scraper
 
 # Run scraper once to bootstrap db then set up cron
-CMD update_trials_store.py --max-id 100 --use-sql --host ${GRAPHQL_HOST} --port ${GRAPHQL_PORT} && sleep ${SECONDS_BETWEEN_SCRAPES}
+CMD update_trials_store.py --max-id ${SCRAPER_MAX_ID} ${SCRAPER_USE_SQL_FLAG} --host ${GRAPHQL_HOST} --port ${GRAPHQL_PORT} && sleep ${SECONDS_BETWEEN_SCRAPES}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.5-alpine
+# Using debian buster because this: https://pythonspeed.com/articles/base-image-python-docker-images/
+FROM python:3.7-slim-buster
 
 WORKDIR /app
 COPY clinical_trials_api_scraper /app/clinical-trials-api-scraper/clinical_trials_api_scraper
@@ -6,10 +7,5 @@ COPY setup.py /app/clinical-trials-api-scraper
 
 RUN pip install /app/clinical-trials-api-scraper
 
-#Set up cron
-COPY daily-trials-scraping /etc/cron.d/daily-trials-scraping
-RUN chmod 0644 /etc/cron.d/daily-trials-scraping
-RUN crontab /etc/cron.d/daily-trials-scraping
-
 # Run scraper once to bootstrap db then set up cron
-CMD update_trials_store.py --max-id 100 && crond -f -l 8
+CMD update_trials_store.py --max-id 100 --host ${GRAPHQL_HOST} --port ${GRAPHQL_PORT} && sleep ${SECONDS_BETWEEN_SCRAPES}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@
 FROM python:3.7-slim-buster
 
 WORKDIR /app
+COPY requirements.txt /app
+RUN pip install -r requirements.txt
+
 COPY clinical_trials_api_scraper /app/clinical-trials-api-scraper/clinical_trials_api_scraper
 COPY setup.py /app/clinical-trials-api-scraper
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ COPY setup.py /app/clinical-trials-api-scraper
 RUN pip install /app/clinical-trials-api-scraper
 
 # Run scraper once to bootstrap db then set up cron
-CMD update_trials_store.py --max-id 100 --host ${GRAPHQL_HOST} --port ${GRAPHQL_PORT} && sleep ${SECONDS_BETWEEN_SCRAPES}
+CMD update_trials_store.py --max-id 100 --use-sql --host ${GRAPHQL_HOST} --port ${GRAPHQL_PORT} && sleep ${SECONDS_BETWEEN_SCRAPES}

--- a/clinical_trials_api_scraper/clients/clinical_trials_rest_client.py
+++ b/clinical_trials_api_scraper/clients/clinical_trials_rest_client.py
@@ -11,16 +11,21 @@ class ClinicalTrialsRestClient(object):
         'OrgFullName',
         'OrgClass',
         'OverallStatus',
-        'StatusVerifiedDate',
+        'OfficialTitle',
+        'Condition',
         'DelayedPosting',
         'WhyStopped',
+        'StartDate',
+        'StatusVerifiedDate',
         'CompletionDate',
-        'CompletionDateType',
         'ResultsFirstSubmitDate',
-        'ResultsFirstSubmitQCDate',
         'ResultsFirstPostDate',
-        'ResultsFirstPostDateType',
+        'LastUpdateSubmitDate',
         'PointOfContactEMail',
+        'PointOfContactOrganization',
+        'ResponsiblePartyInvestigatorFullName',
+        'OverallOfficialAffiliation',
+        'OverallOfficialName',
     ]
     MAX_REQUESTABLE_RECORDS = 1000
 
@@ -34,7 +39,8 @@ class ClinicalTrialsRestClient(object):
     @classmethod
     def request_trials(cls, start_id, end_id=None, requested_fields=None, dry_run=False):
         if start_id < 1:
-            raise IndexError('start_id must be 1 or greater: {}'.format(start_id))
+            raise IndexError(
+                'start_id must be 1 or greater: {}'.format(start_id))
 
         if (end_id+1 - start_id) > cls.MAX_REQUESTABLE_RECORDS:
             raise IndexError(
@@ -88,9 +94,10 @@ class ClinicalTrialsRestClient(object):
             for default_field in cls.DEFAULT_REQUESTED_FIELDS:
                 if default_field in trial:
                     field_value = trial[default_field]
-                    if len(field_value) > 1:
-                        logger.warning(
-                            "Received more than one value for {}: {}".format(default_field, trial)
-                        )
-                    trial[default_field] = field_value[0] if field_value else None
+                    if isinstance(field_value, (list, tuple)):
+                        # TODO: just take the first one for now, this is a hack!
+                        trial[default_field] = field_value[0] if len(
+                            field_value) > 0 else None
+            # delete useless field
+            del trial['Rank']
         return response_data

--- a/clinical_trials_api_scraper/clients/sql_trials_store_client.py
+++ b/clinical_trials_api_scraper/clients/sql_trials_store_client.py
@@ -15,8 +15,6 @@ DB_SCHEMA = "trials_status_schema"
 
 logger = logging.getLogger(__name__)
 
-# Base = declarative_base(cls=DeferredReflection,
-#                         metadata=MetaData(schema=DB_SCHEMA))
 Base = automap_base(metadata=MetaData(schema=DB_SCHEMA))
 
 
@@ -44,6 +42,7 @@ class SqlTrialsStoreClient(TrialsStoreInterfaceBase):
     def store_trials_batch(self, trials_batch):
         logger.info("storing {} values".format(len(trials_batch)))
         trials = [tmu.trial_from_response_data(t) for t in trials_batch]
+        trials = [tmu.add_computed_fields(t) for t in trials]
         for full_trial in trials:
             institution, trial = tmu.split_institution_trial(full_trial)
             inst_obj = Institution(**institution)

--- a/clinical_trials_api_scraper/clients/sql_trials_store_client.py
+++ b/clinical_trials_api_scraper/clients/sql_trials_store_client.py
@@ -18,8 +18,8 @@ logger = logging.getLogger(__name__)
 Base = automap_base(metadata=MetaData(schema=DB_SCHEMA))
 
 
-class Institution(Base):
-    __tablename__ = "institutions"
+class Organization(Base):
+    __tablename__ = "organizations"
 
 
 class Trial(Base):
@@ -37,21 +37,22 @@ class SqlTrialsStoreClient(TrialsStoreInterfaceBase):
         Session = sessionmaker(bind=self.engine)
         self.session = Session()
         logger.info(Trial.__table__.columns)
-        logger.info(Institution.__table__.columns)
+        logger.info(Organization.__table__.columns)
 
     def store_trials_batch(self, trials_batch):
         logger.info("storing {} values".format(len(trials_batch)))
         trials = [tmu.trial_from_response_data(t) for t in trials_batch]
         trials = [tmu.add_computed_fields(t) for t in trials]
         for full_trial in trials:
-            institution, trial = tmu.split_institution_trial(full_trial)
-            inst_obj = Institution(**institution)
+            organization, trial = tmu.split_organization_trial(full_trial)
+            org_obj = Organization(**organization)
 
-            trial["institution"] = inst_obj
+            trial["organization"] = org_obj
             trial_obj = Trial(**trial)
             self.session.merge(trial_obj)
-            logger.info(f"storing trial {trial_obj.id} from {inst_obj.org_full_name}")
+            # logger.info(f"storing trial {trial_obj.id} from {inst_obj.org_full_name}")
         self.session.commit()
+        logger.info("Batch stored.")
 
     def is_ready(self):
         return True

--- a/clinical_trials_api_scraper/clients/sql_trials_store_client.py
+++ b/clinical_trials_api_scraper/clients/sql_trials_store_client.py
@@ -5,8 +5,9 @@ from sqlalchemy.ext.declarative import declarative_base, DeferredReflection
 from sqlalchemy.ext.automap import automap_base
 
 
-from clinical_trials_api_scraper.clients.trials_store_interface_base import \
-    TrialsStoreInterfaceBase
+from clinical_trials_api_scraper.clients.trials_store_interface_base import (
+    TrialsStoreInterfaceBase,
+)
 import clinical_trials_api_scraper.utils.trial_model_utils as tmu
 
 
@@ -20,11 +21,11 @@ Base = automap_base(metadata=MetaData(schema=DB_SCHEMA))
 
 
 class Institution(Base):
-    __tablename__ = 'institutions'
+    __tablename__ = "institutions"
 
 
 class Trial(Base):
-    __tablename__ = 'trials'
+    __tablename__ = "trials"
 
 
 class SqlTrialsStoreClient(TrialsStoreInterfaceBase):
@@ -32,7 +33,8 @@ class SqlTrialsStoreClient(TrialsStoreInterfaceBase):
 
     def __init__(self):
         self.engine = create_engine(
-            'postgres://postgres:1234@db:5432/{}'.format(self.db_name), echo=False)
+            "postgres://postgres:1234@db:5432/{}".format(self.db_name), echo=False
+        )
         Base.prepare(self.engine, reflect=True)
         Session = sessionmaker(bind=self.engine)
         self.session = Session()
@@ -40,17 +42,16 @@ class SqlTrialsStoreClient(TrialsStoreInterfaceBase):
         logger.info(Institution.__table__.columns)
 
     def store_trials_batch(self, trials_batch):
-        logger.info('storing {} values'.format(len(trials_batch)))
+        logger.info("storing {} values".format(len(trials_batch)))
         trials = [tmu.trial_from_response_data(t) for t in trials_batch]
         for full_trial in trials:
             institution, trial = tmu.split_institution_trial(full_trial)
             inst_obj = Institution(**institution)
 
-            trial['institution'] = inst_obj
+            trial["institution"] = inst_obj
             trial_obj = Trial(**trial)
             self.session.merge(trial_obj)
-            logger.info(
-                f'storing trial {trial_obj.id} from {inst_obj.org_full_name}')
+            logger.info(f"storing trial {trial_obj.id} from {inst_obj.org_full_name}")
         self.session.commit()
 
     def is_ready(self):

--- a/clinical_trials_api_scraper/clients/sql_trials_store_client.py
+++ b/clinical_trials_api_scraper/clients/sql_trials_store_client.py
@@ -2,19 +2,21 @@ import logging
 from sqlalchemy import create_engine, MetaData, Table
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.ext.declarative import declarative_base, DeferredReflection
+from sqlalchemy.ext.automap import automap_base
 
 
 from clinical_trials_api_scraper.clients.trials_store_interface_base import \
     TrialsStoreInterfaceBase
-from clinical_trials_api_scraper.utils.trial_model_utils import trial_from_response_data, dict_to_snake_case, extract_institution_from_trial
+import clinical_trials_api_scraper.utils.trial_model_utils as tmu
 
 
 DB_SCHEMA = "trials_status_schema"
 
 logger = logging.getLogger(__name__)
 
-Base = declarative_base(cls=DeferredReflection,
-                        metadata=MetaData(schema=DB_SCHEMA))
+# Base = declarative_base(cls=DeferredReflection,
+#                         metadata=MetaData(schema=DB_SCHEMA))
+Base = automap_base(metadata=MetaData(schema=DB_SCHEMA))
 
 
 class Institution(Base):
@@ -31,7 +33,7 @@ class SqlTrialsStoreClient(TrialsStoreInterfaceBase):
     def __init__(self):
         self.engine = create_engine(
             'postgres://postgres:1234@db:5432/{}'.format(self.db_name), echo=False)
-        Base.prepare(self.engine)
+        Base.prepare(self.engine, reflect=True)
         Session = sessionmaker(bind=self.engine)
         self.session = Session()
         logger.info(Trial.__table__.columns)
@@ -39,15 +41,22 @@ class SqlTrialsStoreClient(TrialsStoreInterfaceBase):
 
     def store_trials_batch(self, trials_batch):
         logger.info('storing {} values'.format(len(trials_batch)))
-        trials = [trial_from_response_data(t) for t in trials_batch]
-        institutions = [dict_to_snake_case(
-            extract_institution_from_trial(t)) for t in trials]
-        for institution in institutions[:5]:
-            logger.info(institution)
-            self.session.add(Institution(**institution))
-        for trial in trials[:5]:
-            logger.info(trial)
-            self.session.add(Trial(**dict_to_snake_case(trial)))
+        trials = [tmu.trial_from_response_data(t) for t in trials_batch]
+        #institution_dict = {}
+        for full_trial in trials:
+            institution, trial = tmu.split_institution_trial(full_trial)
+            inst_obj = Institution(
+                **tmu.dict_to_snake_case(institution))
+            #institution_key = (inst_obj.org_name, inst_obj.org_type)
+
+            # deduplicate institutions
+            #inst_obj = institution_dict.setdefault(institution_key, inst_obj)
+
+            trial['institution'] = inst_obj
+            trial_obj = Trial(**tmu.dict_to_snake_case(trial))
+            self.session.merge(trial_obj)
+            logger.info(
+                f'storing trial {trial_obj.id} from {inst_obj.org_name}')
         self.session.commit()
 
     def is_ready(self):

--- a/clinical_trials_api_scraper/clients/sql_trials_store_client.py
+++ b/clinical_trials_api_scraper/clients/sql_trials_store_client.py
@@ -1,0 +1,54 @@
+import logging
+from sqlalchemy import create_engine, MetaData, Table
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.ext.declarative import declarative_base, DeferredReflection
+
+
+from clinical_trials_api_scraper.clients.trials_store_interface_base import \
+    TrialsStoreInterfaceBase
+from clinical_trials_api_scraper.utils.trial_model_utils import trial_from_response_data, dict_to_snake_case, extract_institution_from_trial
+
+
+DB_SCHEMA = "trials_status_schema"
+
+logger = logging.getLogger(__name__)
+
+Base = declarative_base(cls=DeferredReflection,
+                        metadata=MetaData(schema=DB_SCHEMA))
+
+
+class Institution(Base):
+    __tablename__ = 'institutions'
+
+
+class Trial(Base):
+    __tablename__ = 'trials'
+
+
+class SqlTrialsStoreClient(TrialsStoreInterfaceBase):
+    db_name = "clinical_trials_status"
+
+    def __init__(self):
+        self.engine = create_engine(
+            'postgres://postgres:1234@db:5432/{}'.format(self.db_name), echo=False)
+        Base.prepare(self.engine)
+        Session = sessionmaker(bind=self.engine)
+        self.session = Session()
+        logger.info(Trial.__table__.columns)
+        logger.info(Institution.__table__.columns)
+
+    def store_trials_batch(self, trials_batch):
+        logger.info('storing {} values'.format(len(trials_batch)))
+        trials = [trial_from_response_data(t) for t in trials_batch]
+        institutions = [dict_to_snake_case(
+            extract_institution_from_trial(t)) for t in trials]
+        for institution in institutions[:5]:
+            logger.info(institution)
+            self.session.add(Institution(**institution))
+        for trial in trials[:5]:
+            logger.info(trial)
+            self.session.add(Trial(**dict_to_snake_case(trial)))
+        self.session.commit()
+
+    def is_ready(self):
+        return True

--- a/clinical_trials_api_scraper/clients/sql_trials_store_client.py
+++ b/clinical_trials_api_scraper/clients/sql_trials_store_client.py
@@ -42,21 +42,15 @@ class SqlTrialsStoreClient(TrialsStoreInterfaceBase):
     def store_trials_batch(self, trials_batch):
         logger.info('storing {} values'.format(len(trials_batch)))
         trials = [tmu.trial_from_response_data(t) for t in trials_batch]
-        #institution_dict = {}
         for full_trial in trials:
             institution, trial = tmu.split_institution_trial(full_trial)
-            inst_obj = Institution(
-                **tmu.dict_to_snake_case(institution))
-            #institution_key = (inst_obj.org_name, inst_obj.org_type)
-
-            # deduplicate institutions
-            #inst_obj = institution_dict.setdefault(institution_key, inst_obj)
+            inst_obj = Institution(**institution)
 
             trial['institution'] = inst_obj
-            trial_obj = Trial(**tmu.dict_to_snake_case(trial))
+            trial_obj = Trial(**trial)
             self.session.merge(trial_obj)
             logger.info(
-                f'storing trial {trial_obj.id} from {inst_obj.org_name}')
+                f'storing trial {trial_obj.id} from {inst_obj.org_full_name}')
         self.session.commit()
 
     def is_ready(self):

--- a/clinical_trials_api_scraper/scrapers/clinical_trials_scraper.py
+++ b/clinical_trials_api_scraper/scrapers/clinical_trials_scraper.py
@@ -1,4 +1,7 @@
-from clinical_trials_api_scraper.clients.clinical_trials_rest_client import ClinicalTrialsRestClient
+from clinical_trials_api_scraper.clients.clinical_trials_rest_client import (
+    ClinicalTrialsRestClient,
+)
+
 
 class ClinicalTrialsScraper(object):
     def __init__(self, data_store_client, min_id=1, max_id=None):
@@ -17,14 +20,15 @@ class ClinicalTrialsScraper(object):
         batch_endpoints = list(range(1, self.max_id, max_requestable_records))
         batch_endpoints.append(self.max_id + 1)
         # We could always distribute this if it becomes the bottleneck
-        for start_id, end_id_exclusive in zip(batch_endpoints[:-1], batch_endpoints[1:]):
-            end_id = end_id_exclusive-1
+        for start_id, end_id_exclusive in zip(
+            batch_endpoints[:-1], batch_endpoints[1:]
+        ):
+            end_id = end_id_exclusive - 1
             self._request_and_store_batch(start_id, end_id)
 
     def _request_and_store_batch(self, start_id, end_id):
         trials_batch = ClinicalTrialsRestClient.request_trials(
-            start_id=start_id,
-            end_id=end_id,
+            start_id=start_id, end_id=end_id,
         )
         self._store_batch_data(trials_batch)
 

--- a/clinical_trials_api_scraper/scripts/update_trials_store.py
+++ b/clinical_trials_api_scraper/scripts/update_trials_store.py
@@ -12,14 +12,16 @@ logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-def main(min_id=None, max_id=None, in_memory=False):
+def main(min_id=None, max_id=None, in_memory=False, host="localhost", port=5000):
+    logger.info("I am different3")
     if in_memory:
         store = InMemoryTrialsStoreClient()
     else:
-        store = GqlTrialsStoreClient()
+        store = GqlTrialsStoreClient(host, port)
     if not store.is_ready():
         raise ValueError("Store not ready for data")
-    scraper = ClinicalTrialsScraper(data_store_client=store, min_id=min_id, max_id=max_id)
+    scraper = ClinicalTrialsScraper(
+        data_store_client=store, min_id=min_id, max_id=max_id)
     scraper.scrape_all_trials()
     logger.info("Completed scraping trials")
 
@@ -31,10 +33,16 @@ if __name__ == "__main__":
     parser.add_argument("--min-id", type=int, required=False)
     parser.add_argument("--max-id", type=int, required=False)
     parser.add_argument("--in-memory", action='store_true')
+    parser.add_argument("--host")
+    parser.add_argument("--port")
     args = parser.parse_args()
+
+    logger.info(args)
 
     main(
         min_id=args.min_id,
         max_id=args.max_id,
-        in_memory=args.in_memory
+        in_memory=args.in_memory,
+        host=args.host,
+        port=args.port
     )

--- a/clinical_trials_api_scraper/scripts/update_trials_store.py
+++ b/clinical_trials_api_scraper/scripts/update_trials_store.py
@@ -2,18 +2,36 @@
 import logging
 import sys
 
-from clinical_trials_api_scraper.clients.in_memory_trials_store_client import \
-    InMemoryTrialsStoreClient
-from clinical_trials_api_scraper.clients.gql_trials_store_client import GqlTrialsStoreClient
-from clinical_trials_api_scraper.clients.sql_trials_store_client import SqlTrialsStoreClient
-from clinical_trials_api_scraper.scrapers.clinical_trials_scraper import ClinicalTrialsScraper
+from clinical_trials_api_scraper.clients.in_memory_trials_store_client import (
+    InMemoryTrialsStoreClient,
+)
+from clinical_trials_api_scraper.clients.gql_trials_store_client import (
+    GqlTrialsStoreClient,
+)
+from clinical_trials_api_scraper.clients.sql_trials_store_client import (
+    SqlTrialsStoreClient,
+)
+from clinical_trials_api_scraper.scrapers.clinical_trials_scraper import (
+    ClinicalTrialsScraper,
+)
 
 
-logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+logging.basicConfig(
+    stream=sys.stdout,
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(message)s",
+)
 logger = logging.getLogger(__name__)
 
 
-def main(min_id=None, max_id=None, in_memory=False, use_sql=False, host="localhost", port=5000):
+def main(
+    min_id=None,
+    max_id=None,
+    in_memory=False,
+    use_sql=False,
+    host="localhost",
+    port=5000,
+):
     if in_memory:
         store = InMemoryTrialsStoreClient()
     elif use_sql:
@@ -23,7 +41,8 @@ def main(min_id=None, max_id=None, in_memory=False, use_sql=False, host="localho
     if not store.is_ready():
         raise ValueError("Store not ready for data")
     scraper = ClinicalTrialsScraper(
-        data_store_client=store, min_id=min_id, max_id=max_id)
+        data_store_client=store, min_id=min_id, max_id=max_id
+    )
     scraper.scrape_all_trials()
     logger.info("Completed scraping trials")
 
@@ -34,8 +53,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--min-id", type=int, required=False)
     parser.add_argument("--max-id", type=int, required=False)
-    parser.add_argument("--in-memory", action='store_true')
-    parser.add_argument("--use-sql", action='store_true')
+    parser.add_argument("--in-memory", action="store_true")
+    parser.add_argument("--use-sql", action="store_true")
     parser.add_argument("--host")
     parser.add_argument("--port")
     args = parser.parse_args()
@@ -48,5 +67,5 @@ if __name__ == "__main__":
         in_memory=args.in_memory,
         use_sql=args.use_sql,
         host=args.host,
-        port=args.port
+        port=args.port,
     )

--- a/clinical_trials_api_scraper/scripts/update_trials_store.py
+++ b/clinical_trials_api_scraper/scripts/update_trials_store.py
@@ -5,6 +5,7 @@ import sys
 from clinical_trials_api_scraper.clients.in_memory_trials_store_client import \
     InMemoryTrialsStoreClient
 from clinical_trials_api_scraper.clients.gql_trials_store_client import GqlTrialsStoreClient
+from clinical_trials_api_scraper.clients.sql_trials_store_client import SqlTrialsStoreClient
 from clinical_trials_api_scraper.scrapers.clinical_trials_scraper import ClinicalTrialsScraper
 
 
@@ -12,9 +13,11 @@ logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-def main(min_id=None, max_id=None, in_memory=False, host="localhost", port=5000):
+def main(min_id=None, max_id=None, in_memory=False, use_sql=False, host="localhost", port=5000):
     if in_memory:
         store = InMemoryTrialsStoreClient()
+    elif use_sql:
+        store = SqlTrialsStoreClient()
     else:
         store = GqlTrialsStoreClient(host, port)
     if not store.is_ready():
@@ -32,6 +35,7 @@ if __name__ == "__main__":
     parser.add_argument("--min-id", type=int, required=False)
     parser.add_argument("--max-id", type=int, required=False)
     parser.add_argument("--in-memory", action='store_true')
+    parser.add_argument("--use-sql", action='store_true')
     parser.add_argument("--host")
     parser.add_argument("--port")
     args = parser.parse_args()
@@ -42,6 +46,7 @@ if __name__ == "__main__":
         min_id=args.min_id,
         max_id=args.max_id,
         in_memory=args.in_memory,
+        use_sql=args.use_sql,
         host=args.host,
         port=args.port
     )

--- a/clinical_trials_api_scraper/scripts/update_trials_store.py
+++ b/clinical_trials_api_scraper/scripts/update_trials_store.py
@@ -13,7 +13,6 @@ logger = logging.getLogger(__name__)
 
 
 def main(min_id=None, max_id=None, in_memory=False, host="localhost", port=5000):
-    logger.info("I am different3")
     if in_memory:
         store = InMemoryTrialsStoreClient()
     else:

--- a/clinical_trials_api_scraper/utils/trial_model_utils.py
+++ b/clinical_trials_api_scraper/utils/trial_model_utils.py
@@ -34,7 +34,9 @@ def split_institution_trial(full_trial):
     trial = full_trial.copy()
     institution = {}
     for field in INSTITUTION_FIELDS:
-        institution[field] = trial.pop(field)
+        value = trial.pop(field)
+        value = '' if value is None else value
+        institution[field] = value
     return institution, trial
 
 

--- a/clinical_trials_api_scraper/utils/trial_model_utils.py
+++ b/clinical_trials_api_scraper/utils/trial_model_utils.py
@@ -68,7 +68,7 @@ def add_computed_fields(trial):
     is_missing: the trial results should have been reported by now but are missing
     """
     one_year = dt.timedelta(365)
-    one_year_ago = dt.datetime.now() - one_year
+    one_year_ago = trial["data_version"] - one_year
     # logger.info(trial)
     completion_date = trial["completion_date"]
     trial["should_have_results"] = (

--- a/clinical_trials_api_scraper/utils/trial_model_utils.py
+++ b/clinical_trials_api_scraper/utils/trial_model_utils.py
@@ -22,11 +22,13 @@ DATE_FIELDS = ['completionDate', 'clinicaltrialsUpdatedAt']
 
 INSTITUTION_FIELDS = ['orgName', 'orgType']
 
+
 def extract_institution_from_trial(trial):
     institution = {}
     for field in INSTITUTION_FIELDS:
         institution[field] = trial.pop(field)
     return institution
+
 
 def trial_from_response_data(response_data):
     trial_model = {
@@ -36,5 +38,16 @@ def trial_from_response_data(response_data):
 
     for time_field in DATE_FIELDS:
         if trial_model.get(time_field):
-            trial_model[time_field] = parser.parse(trial_model[time_field]).isoformat()
+            trial_model[time_field] = parser.parse(
+                trial_model[time_field]).isoformat()
     return trial_model
+
+
+def dict_to_snake_case(d):
+    return {to_snake_case(k): v for k, v in d.items()}
+
+
+def to_snake_case(str):
+
+    return ''.join(['_'+i.lower() if i.isupper()
+                    else i for i in str]).lstrip('_')

--- a/clinical_trials_api_scraper/utils/trial_model_utils.py
+++ b/clinical_trials_api_scraper/utils/trial_model_utils.py
@@ -30,6 +30,14 @@ def extract_institution_from_trial(trial):
     return institution
 
 
+def split_institution_trial(full_trial):
+    trial = full_trial.copy()
+    institution = {}
+    for field in INSTITUTION_FIELDS:
+        institution[field] = trial.pop(field)
+    return institution, trial
+
+
 def trial_from_response_data(response_data):
     trial_model = {
         new_key: response_data.get(old_key) for new_key, old_key in RESPONSE_TO_TRIAL_MAP.items()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+python-dateutil==2.8.0
+requests==2.22.0
+requests-cache==0.5.2
+SQLAlchemy==1.3.11
+psycopg2-binary==2.8.4

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,19 @@
 from setuptools import find_packages, setup
 
 setup(
-    name='clinical_trials_api_scraper',
-    version='0.1.0',
-    author='David Stuck',
+    name="clinical_trials_api_scraper",
+    version="0.1.0",
+    author="David Stuck",
     packages=find_packages(),
-    scripts=['clinical_trials_api_scraper/scripts/update_trials_store.py'],
-    url='https://github.com/dstuck/clinical-trials-api-scraper',
-    description='Scraper to pull trial reporting data from clinicaltrials.gov.',
+    scripts=["clinical_trials_api_scraper/scripts/update_trials_store.py"],
+    url="https://github.com/dstuck/clinical-trials-api-scraper",
+    description="Scraper to pull trial reporting data from clinicaltrials.gov.",
     # long_description=open('README.md').read(),
-    install_requires=[
-        "requests",
-        "python-dateutil",
-        "sqlalchemy",
-        "psycopg2-binary"
-    ],
+    # Not using install_requires: it can't be cached effectively
+    # install_requires=[
+    #     "requests",
+    #     "python-dateutil",
+    #     "sqlalchemy",
+    #     "psycopg2-binary"
+    # ],
 )

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,8 @@ setup(
     # long_description=open('README.md').read(),
     install_requires=[
         "requests",
-        "python-dateutil"
+        "python-dateutil",
+        "sqlalchemy",
+        "psycopg2-binary"
     ],
 )


### PR DESCRIPTION
Create a scraper MVP

Changes:

- Scrape more fields
- switch to `black` as code formatter (annoying format changes)
- do conversion into models in a more general way
- compute trial fields like `is_late` in the scraper itself (performance improvement)
- improve caching of docker image on build by using `requirements.txt`
